### PR TITLE
fix: move tslib to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,6 @@ sdk.placeOrder({
 
 ## Other language implementations
 
-| Language | Link                                                        | Type             |
-| -------- | ----------------------------------------------------------- | ---------------- |
+| Language | Link                                                                  | Type             |
+| -------- | --------------------------------------------------------------------- | ---------------- |
 | rust     | [frolovdev/fusion-sdk-rs](https://github.com/frolovdev/fusion-sdk-rs) | Community driven |

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
         "@metamask/eth-sig-util": "^5.0.2",
         "bn.js": "^5.2.1",
         "web3": "^1.8.1",
-        "ws": "^8.12.1"
+        "ws": "^8.12.1",
+        "tslib": "^2.2.0"
     },
     "devDependencies": {
         "@babel/core": "^7.13.16",
@@ -58,7 +59,6 @@
         "ts-loader": "^9.0.2",
         "ts-mockito": "^2.6.1",
         "ts-node": "^10.4.0",
-        "tslib": "^2.2.0",
         "typescript": "4.7.4"
     },
     "peerDependencies": {


### PR DESCRIPTION
Right now if you tried to install sdk in node.js project without typescript you will face the issue that we can't resolve tslib dep, which is not so great UX

The other option can be to remove compiler flag importHelpers at all