### PR TITLE
feat: add preInteraction support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@1inch/fusion-sdk",
-    "version": "2.4.6-rc.2",
+    "version": "2.4.6-rc.3",
     "description": "1inch Fusion SDK",
     "author": "@1inch",
     "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@1inch/fusion-sdk",
-    "version": "2.4.6-rc.1",
+    "version": "2.4.6-rc.2",
     "description": "1inch Fusion SDK",
     "author": "@1inch",
     "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@1inch/fusion-sdk",
-    "version": "2.4.6",
+    "version": "2.4.6-rc.1",
     "description": "1inch Fusion SDK",
     "author": "@1inch",
     "files": [

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     },
     "dependencies": {
         "@1inch/byte-utils": "^3.1.0",
-        "@1inch/limit-order-sdk": "5.2.2",
+        "@1inch/limit-order-sdk": "5.2.5",
         "ethers": "6.16.0",
         "tslib": "^2.8.1",
         "ws": "^8.18.2"

--- a/package.json
+++ b/package.json
@@ -109,6 +109,5 @@
             "glob@>=10.2.0 <10.5.0": ">=10.5.0",
             "@isaacs/brace-expansion@<=5.0.0": ">=5.0.1"
         }
-    },
-    "packageManager": "pnpm@10.26.2+sha512.0e308ff2005fc7410366f154f625f6631ab2b16b1d2e70238444dd6ae9d630a8482d92a451144debc492416896ed16f7b114a86ec68b8404b2443869e68ffda6"
+    }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0(assert@2.1.0)
       '@1inch/limit-order-sdk':
-        specifier: 5.2.2
-        version: 5.2.2(assert@2.1.0)(axios@1.12.2)
+        specifier: 5.2.5
+        version: 5.2.5(assert@2.1.0)(axios@1.12.2)
       assert:
         specifier: ^2.0.0
         version: 2.1.0
@@ -125,13 +125,10 @@ importers:
 packages:
 
   '@1inch/byte-utils@3.0.0':
-    resolution: {integrity: sha512-CuX4E0z/pzo9hKGzFsMi3vPVgHRRh14ZwNEZ5TY1svnKF8PjxWx3t0CjXCW4dyqKGe6TKAzgYqzzxrMrWPDy5Q==}
+    resolution: {integrity: sha512-CuX4E0z/pzo9hKGzFsMi3vPVgHRRh14ZwNEZ5TY1svnKF8PjxWx3t0CjXCW4dyqKGe6TKAzgYqzzxrMrWPDy5Q==, tarball: https://npm.pkg.github.com/download/@1inch/byte-utils/3.0.0/1c573a3e72586540ea6f542099cd18da978118df}
     engines: {node: '>=18.16.0'}
     peerDependencies:
       assert: ^2.0.0
-    peerDependenciesMeta:
-      assert:
-        optional: true
 
   '@1inch/byte-utils@3.1.0':
     resolution: {integrity: sha512-fMxihTlLKvRvy3gvL16DTWkZGDwQXYSEgCLX/+sazb38+YD7IK3HzKaxvAUzg8ODLwQk5oY/o6pqRQKI+9x+OA==}
@@ -164,17 +161,12 @@ packages:
       prettier: ^3.3.2
       typescript: ^5.5.2
 
-  '@1inch/limit-order-sdk@5.2.2':
-    resolution: {integrity: sha512-zUvo4kpc1hCUx2znUUhYrRl2vdAsao6ubJIUngtM5Kpz07zHKLIIS/FarY2AktZeHQiUTotTrj7C1h9HjCQYow==}
+  '@1inch/limit-order-sdk@5.2.5':
+    resolution: {integrity: sha512-TvITGypMTzVnJ9B9CjFd1XILnF5tE/Uvy8/DCGCcHOcshEI99mfucgg3DwLoQTpzOcRcDHJ4FbYq9j4T6SUJ9A==, tarball: https://npm.pkg.github.com/download/@1inch/limit-order-sdk/5.2.5/05ebb8f6e44a2c54127c70b034e4a4a75d365a83}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       assert: ^2.0.0
       axios: '>=1.7.4'
-    peerDependenciesMeta:
-      assert:
-        optional: true
-      axios:
-        optional: true
 
   '@1inch/tsconfig@1.0.8':
     resolution: {integrity: sha512-j9N4YPEo/QbGMuB5jP26Upb5P7qiO5H3w9rNtort5VD++LY7y8WD69fVEC/8hSAXxpQ0EHH1N2pY4oavwztyZQ==}
@@ -1952,10 +1944,6 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  ethers@6.13.5:
-    resolution: {integrity: sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ==}
-    engines: {node: '>=14.0.0'}
-
   ethers@6.16.0:
     resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
     engines: {node: '>=14.0.0'}
@@ -3628,7 +3616,7 @@ packages:
 snapshots:
 
   '@1inch/byte-utils@3.0.0(assert@2.1.0)':
-    optionalDependencies:
+    dependencies:
       assert: 2.1.0
 
   '@1inch/byte-utils@3.1.0(assert@2.1.0)':
@@ -3657,13 +3645,12 @@ snapshots:
       semver: 7.7.2
       typescript: 5.7.3
 
-  '@1inch/limit-order-sdk@5.2.2(assert@2.1.0)(axios@1.12.2)':
+  '@1inch/limit-order-sdk@5.2.5(assert@2.1.0)(axios@1.12.2)':
     dependencies:
       '@1inch/byte-utils': 3.0.0(assert@2.1.0)
-      ethers: 6.13.5
-    optionalDependencies:
       assert: 2.1.0
       axios: 1.12.2
+      ethers: 6.16.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -5780,19 +5767,6 @@ snapshots:
   estraverse@5.3.0: {}
 
   esutils@2.0.3: {}
-
-  ethers@6.13.5:
-    dependencies:
-      '@adraffy/ens-normalize': 1.10.1
-      '@noble/curves': 1.2.0
-      '@noble/hashes': 1.3.2
-      '@types/node': 22.7.5
-      aes-js: 4.0.0-beta.5
-      tslib: 2.7.0
-      ws: 8.17.1
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   ethers@6.16.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,10 +125,13 @@ importers:
 packages:
 
   '@1inch/byte-utils@3.0.0':
-    resolution: {integrity: sha512-CuX4E0z/pzo9hKGzFsMi3vPVgHRRh14ZwNEZ5TY1svnKF8PjxWx3t0CjXCW4dyqKGe6TKAzgYqzzxrMrWPDy5Q==, tarball: https://npm.pkg.github.com/download/@1inch/byte-utils/3.0.0/1c573a3e72586540ea6f542099cd18da978118df}
+    resolution: {integrity: sha512-CuX4E0z/pzo9hKGzFsMi3vPVgHRRh14ZwNEZ5TY1svnKF8PjxWx3t0CjXCW4dyqKGe6TKAzgYqzzxrMrWPDy5Q==}
     engines: {node: '>=18.16.0'}
     peerDependencies:
       assert: ^2.0.0
+    peerDependenciesMeta:
+      assert:
+        optional: true
 
   '@1inch/byte-utils@3.1.0':
     resolution: {integrity: sha512-fMxihTlLKvRvy3gvL16DTWkZGDwQXYSEgCLX/+sazb38+YD7IK3HzKaxvAUzg8ODLwQk5oY/o6pqRQKI+9x+OA==}
@@ -162,11 +165,16 @@ packages:
       typescript: ^5.5.2
 
   '@1inch/limit-order-sdk@5.2.5':
-    resolution: {integrity: sha512-TvITGypMTzVnJ9B9CjFd1XILnF5tE/Uvy8/DCGCcHOcshEI99mfucgg3DwLoQTpzOcRcDHJ4FbYq9j4T6SUJ9A==, tarball: https://npm.pkg.github.com/download/@1inch/limit-order-sdk/5.2.5/05ebb8f6e44a2c54127c70b034e4a4a75d365a83}
+    resolution: {integrity: sha512-TvITGypMTzVnJ9B9CjFd1XILnF5tE/Uvy8/DCGCcHOcshEI99mfucgg3DwLoQTpzOcRcDHJ4FbYq9j4T6SUJ9A==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       assert: ^2.0.0
       axios: '>=1.7.4'
+    peerDependenciesMeta:
+      assert:
+        optional: true
+      axios:
+        optional: true
 
   '@1inch/tsconfig@1.0.8':
     resolution: {integrity: sha512-j9N4YPEo/QbGMuB5jP26Upb5P7qiO5H3w9rNtort5VD++LY7y8WD69fVEC/8hSAXxpQ0EHH1N2pY4oavwztyZQ==}
@@ -3616,7 +3624,7 @@ packages:
 snapshots:
 
   '@1inch/byte-utils@3.0.0(assert@2.1.0)':
-    dependencies:
+    optionalDependencies:
       assert: 2.1.0
 
   '@1inch/byte-utils@3.1.0(assert@2.1.0)':
@@ -3648,9 +3656,10 @@ snapshots:
   '@1inch/limit-order-sdk@5.2.5(assert@2.1.0)(axios@1.12.2)':
     dependencies:
       '@1inch/byte-utils': 3.0.0(assert@2.1.0)
+      ethers: 6.16.0
+    optionalDependencies:
       assert: 2.1.0
       axios: 1.12.2
-      ethers: 6.16.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate

--- a/src/fusion-order/fusion-extension.ts
+++ b/src/fusion-order/fusion-extension.ts
@@ -119,10 +119,9 @@ export class FusionExtension {
             ? Interaction.decode(extension.makerPermit)
             : undefined
 
-        const preInteraction =
-            extension.preInteraction !== ZX
-                ? Interaction.decode(extension.preInteraction)
-                : undefined
+        const preInteraction = extension.hasPreInteraction
+            ? Interaction.decode(extension.preInteraction)
+            : undefined
 
         assert(
             amountData.fees.integratorFee.value ===

--- a/src/fusion-order/fusion-extension.ts
+++ b/src/fusion-order/fusion-extension.ts
@@ -15,7 +15,6 @@ import {Whitelist} from './whitelist/whitelist.js'
 import {SurplusParams} from './surplus-params.js'
 import {Fees, IntegratorFee, ResolverFee} from './fees/index.js'
 import {add0x} from '../utils.js'
-import {ZX} from '../constants.js'
 
 export class FusionExtension {
     /**

--- a/src/fusion-order/fusion-extension.ts
+++ b/src/fusion-order/fusion-extension.ts
@@ -15,6 +15,7 @@ import {Whitelist} from './whitelist/whitelist.js'
 import {SurplusParams} from './surplus-params.js'
 import {Fees, IntegratorFee, ResolverFee} from './fees/index.js'
 import {add0x} from '../utils.js'
+import {ZX} from '../constants.js'
 
 export class FusionExtension {
     /**
@@ -30,6 +31,7 @@ export class FusionExtension {
         public readonly surplus: SurplusParams,
         public readonly extra?: {
             makerPermit?: Interaction
+            preInteraction?: Interaction
             customReceiver?: Address
             fees?: Fees
         }
@@ -117,6 +119,11 @@ export class FusionExtension {
             ? Interaction.decode(extension.makerPermit)
             : undefined
 
+        const preInteraction =
+            extension.preInteraction !== ZX
+                ? Interaction.decode(extension.preInteraction)
+                : undefined
+
         assert(
             amountData.fees.integratorFee.value ===
                 interactionData.fees.integratorFee.value,
@@ -160,6 +167,7 @@ export class FusionExtension {
                 surplusParams,
                 {
                     makerPermit,
+                    preInteraction,
                     customReceiver,
                     fees: undefined
                 }
@@ -189,6 +197,7 @@ export class FusionExtension {
             surplusParams,
             {
                 makerPermit,
+                preInteraction,
                 fees,
                 customReceiver
             }
@@ -210,6 +219,10 @@ export class FusionExtension {
                 this.extra?.makerPermit.target,
                 this.extra?.makerPermit.data
             )
+        }
+
+        if (this.extra?.preInteraction) {
+            builder.withPreInteraction(this.extra.preInteraction)
         }
 
         return builder.build()

--- a/src/fusion-order/fusion-order.spec.ts
+++ b/src/fusion-order/fusion-order.spec.ts
@@ -3,6 +3,7 @@ import {
     Bps,
     MakerTraits,
     Extension,
+    Interaction,
     ProxyFactory
 } from '@1inch/limit-order-sdk'
 import {parseEther, parseUnits} from 'ethers'
@@ -789,5 +790,194 @@ describe('FusionOrder Native', () => {
         )
 
         expect(nativeOrder.build().receiver).toEqual(settlementExt.toString())
+    })
+})
+
+describe('FusionOrder preInteraction', () => {
+    it('should create order with preInteraction and set PRE_INTERACTION_CALL_FLAG in makerTraits', () => {
+        const extensionContract = new Address(
+            '0x2ad5004c60e16e54d5007c80ce329adde5b51ef5'
+        )
+
+        const preInteraction = new Interaction(
+            new Address('0x3a617c2fbaf8d7c58c793fbbd2d14eb4927876c1'),
+            '0xdeadbeef01020304'
+        )
+
+        const order = FusionOrder.new(
+            extensionContract,
+            {
+                makerAsset: new Address(
+                    '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c'
+                ),
+                takerAsset: new Address(
+                    '0xda7ad9dea9397cffddae2f8a052b82f1484252b3'
+                ),
+                makingAmount: 1983000000000000n,
+                takingAmount: 79052953622246027n,
+                maker: new Address('0x3a617c2fbaf8d7c58c793fbbd2d14eb4927876c1')
+            },
+            {
+                auction: new AuctionDetails({
+                    duration: 180n,
+                    startTime: 1673548149n,
+                    initialRateBump: 50000,
+                    points: [{coefficient: 20000, delay: 12}]
+                }),
+                whitelist: Whitelist.new(1673548139n, [
+                    {
+                        address: new Address(
+                            '0x00000000219ab540356cbb839cbe05303d7705fa'
+                        ),
+                        allowFrom: 0n
+                    }
+                ]),
+                surplus: SurplusParams.NO_FEE
+            },
+            {
+                preInteraction: preInteraction.encode()
+            }
+        )
+
+        const makerTraits = new MakerTraits(BigInt(order.build().makerTraits))
+
+        expect(makerTraits.hasPreInteraction()).toBe(true)
+    })
+
+    it('should not set PRE_INTERACTION_CALL_FLAG when no preInteraction', () => {
+        const extensionContract = new Address(
+            '0x2ad5004c60e16e54d5007c80ce329adde5b51ef5'
+        )
+
+        const order = FusionOrder.new(
+            extensionContract,
+            {
+                makerAsset: new Address(
+                    '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c'
+                ),
+                takerAsset: new Address(
+                    '0xda7ad9dea9397cffddae2f8a052b82f1484252b3'
+                ),
+                makingAmount: 1983000000000000n,
+                takingAmount: 79052953622246027n,
+                maker: new Address('0x3a617c2fbaf8d7c58c793fbbd2d14eb4927876c1')
+            },
+            {
+                auction: new AuctionDetails({
+                    duration: 180n,
+                    startTime: 1673548149n,
+                    initialRateBump: 50000,
+                    points: [{coefficient: 20000, delay: 12}]
+                }),
+                whitelist: Whitelist.new(1673548139n, [
+                    {
+                        address: new Address(
+                            '0x00000000219ab540356cbb839cbe05303d7705fa'
+                        ),
+                        allowFrom: 0n
+                    }
+                ]),
+                surplus: SurplusParams.NO_FEE
+            }
+        )
+
+        const makerTraits = new MakerTraits(BigInt(order.build().makerTraits))
+
+        expect(makerTraits.hasPreInteraction()).toBe(false)
+    })
+
+    it('should round-trip order with preInteraction via fromDataAndExtension', () => {
+        const extensionContract = new Address(
+            '0x2ad5004c60e16e54d5007c80ce329adde5b51ef5'
+        )
+
+        const preInteractionTarget = new Address(
+            '0x3a617c2fbaf8d7c58c793fbbd2d14eb4927876c1'
+        )
+        const preInteractionCalldata =
+            '0x0599a1fd1975848548e5b765925a935093a96ecc6f2ca216f77dcfd328b8a491'
+        const preInteraction = new Interaction(
+            preInteractionTarget,
+            preInteractionCalldata
+        )
+
+        const order = FusionOrder.new(
+            extensionContract,
+            {
+                makerAsset: new Address(
+                    '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c'
+                ),
+                takerAsset: new Address(
+                    '0xda7ad9dea9397cffddae2f8a052b82f1484252b3'
+                ),
+                makingAmount: 1983000000000000n,
+                takingAmount: 79052953622246027n,
+                maker: new Address('0x3a617c2fbaf8d7c58c793fbbd2d14eb4927876c1')
+            },
+            {
+                auction: new AuctionDetails({
+                    duration: 180n,
+                    startTime: 1673548149n,
+                    initialRateBump: 50000,
+                    points: [{coefficient: 20000, delay: 12}]
+                }),
+                whitelist: Whitelist.new(1673548139n, [
+                    {
+                        address: new Address(
+                            '0x00000000219ab540356cbb839cbe05303d7705fa'
+                        ),
+                        allowFrom: 0n
+                    }
+                ]),
+                surplus: SurplusParams.NO_FEE
+            },
+            {
+                preInteraction: preInteraction.encode()
+            }
+        )
+
+        const built = order.build()
+        const extension = order.extension
+
+        const restored = FusionOrder.fromDataAndExtension(
+            {
+                salt: built.salt,
+                maker: built.maker,
+                receiver: built.receiver,
+                makerAsset: built.makerAsset,
+                takerAsset: built.takerAsset,
+                makerTraits: built.makerTraits,
+                makingAmount: built.makingAmount,
+                takingAmount: built.takingAmount
+            },
+            extension
+        )
+
+        expect(restored.build().salt).toEqual(built.salt)
+        expect(restored.extension.encode()).toEqual(extension.encode())
+    })
+
+    it('should validate OKX order with preInteraction (real customer data)', () => {
+        const extensionHex =
+            '0x000002b800000207000000d2000000d2000000d20000006900000000000000002ad5004c60e16e54d5007c80ce329adde5b51ef50000000000000069c930cb0000b403e4e400000000000064062324dfe7924cb4f3257d000000000000000000006ea9a11ae13b29f5c555d18bd45f0b94f54a968faa848f727be12534f24895770895ad27ad6b0d952ad5004c60e16e54d5007c80ce329adde5b51ef50000000000000069c930cb0000b403e4e400000000000064062324dfe7924cb4f3257d000000000000000000006ea9a11ae13b29f5c555d18bd45f0b94f54a968faa848f727be12534f24895770895ad27ad6b0d953a617c2fbaf8d7c58c793fbbd2d14eb4927876c10100000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000070b872a96f0000000000000000000000000000000000000000000000000006715eae5b898683d0000000000000000000000000000000000000000000000000000000069c931e800000000000000000000000000000000000000000000000000000000000000410599a1fd1975848548e5b765925a935093a96ecc6f2ca216f77dcfd328b8a4917028648ec3e33d048184f9877d4892fb829ddc5d75a19c1c2ef064d2a38c012b1b000000000000000000000000000000000000000000000000000000000000002ad5004c60e16e54d5007c80ce329adde5b51ef500000000000000000000000000000000000000000090cbe4bdd538d6e9b379bff5fe72c3d67a521de500000000006469c930cb062324dfe7924cb4f3257d000c0000000000000000000000006ea9a11ae13b29f5c5550000d18bd45f0b94f54a968f0000aa848f727be12534f248000095770895ad27ad6b0d950000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00'
+
+        const extension = Extension.decode(extensionHex)
+
+        expect(() => {
+            FusionOrder.fromDataAndExtension(
+                {
+                    maker: '0x3a617c2fbaf8d7c58c793fbbd2d14eb4927876c1',
+                    makerAsset: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',
+                    makerTraits:
+                        '69656178681823023809491920669288819567982727296017585526061607372909138935808',
+                    makingAmount: '1983000000000000',
+                    receiver: '0xb698362cc878094c406115efeeb13089b544e6c8',
+                    salt: '1084071965642925953405739669729447852001208220133',
+                    takerAsset: '0xda7ad9dea9397cffddae2f8a052b82f1484252b3',
+                    takingAmount: '79052953622246027'
+                },
+                extension
+            )
+        }).not.toThrow()
     })
 })

--- a/src/fusion-order/fusion-order.ts
+++ b/src/fusion-order/fusion-order.ts
@@ -57,6 +57,9 @@ export class FusionOrder {
                 makerPermit: extra.permit
                     ? new Interaction(orderInfo.makerAsset, extra.permit)
                     : undefined,
+                preInteraction: extra.preInteraction
+                    ? Interaction.decode(extra.preInteraction)
+                    : undefined,
                 customReceiver: orderInfo.receiver,
                 fees: extra?.fees
             }
@@ -100,6 +103,10 @@ export class FusionOrder {
 
         if (enablePermit2) {
             makerTraits.enablePermit2()
+        }
+
+        if (extra.preInteraction) {
+            makerTraits.enablePreInteraction()
         }
 
         if (extra.nonce !== undefined) {
@@ -393,6 +400,10 @@ export class FusionOrder {
                     extension.makerPermit === ZX
                         ? undefined
                         : Interaction.decode(extension.makerPermit).data,
+                preInteraction:
+                    extension.preInteraction === ZX
+                        ? undefined
+                        : extension.preInteraction,
                 unwrapWETH: makerTraits.isNativeUnwrapEnabled(),
                 orderExpirationDelay,
                 fees: extra?.fees,

--- a/src/fusion-order/types.ts
+++ b/src/fusion-order/types.ts
@@ -12,6 +12,13 @@ export type Extra = {
     nonce?: bigint
     permit?: string
     /**
+     * Encoded pre-interaction: target address (20 bytes) followed by calldata.
+     * Format matches `Interaction.encode()`: `0x{target}{calldata}`.
+     * When set, the PRE_INTERACTION_CALL_FLAG is enabled in makerTraits
+     * and the LOP contract calls IPreInteraction on the target before the swap.
+     */
+    preInteraction?: string
+    /**
      * Default is true
      */
     allowPartialFills?: boolean


### PR DESCRIPTION
## Change Summary
**What does this PR change?**
## Fix: preserve `preInteraction` in extension round-trip

### Problem

Orders containing a `preInteraction` field (e.g., Permit2 approve-then-swap flows used by OKX) were rejected with `"invalid salt for passed extension"`.

When `FusionOrder.fromDataAndExtension()` validates an incoming order, it decodes the extension, rebuilds it from parsed fields, and compares the hash against the salt. The `preInteraction` field was silently dropped during rebuild, producing a shorter extension with a different hash — causing the salt mismatch.

### Changes

- **`types.ts`** — Add optional `preInteraction?: string` to `Extra` with JSDoc documenting the `0x{target}{calldata}` format
- **`fusion-order.ts`**
  - Constructor: decode `extra.preInteraction` and pass to `FusionExtension`
  - Constructor: set `PRE_INTERACTION_CALL_FLAG` (bit 252) in `makerTraits` when present
  - `fromDataAndExtension()`: preserve `extension.preInteraction` through to the constructor
- **`fusion-extension.ts`**
  - Add `preInteraction?: Interaction` to constructor's `extra` type
  - `fromExtension()`: parse `preInteraction` from `Extension` bytes
  - `build()`: emit `preInteraction` via `ExtensionBuilder.withPreInteraction()`
  - Pass through both return paths (with-fees and no-fees)
- **`fusion-order.spec.ts`** — 4 new tests:
  - `preInteraction` sets `PRE_INTERACTION_CALL_FLAG` in makerTraits
  - Flag not set when `preInteraction` is absent
  - Full round-trip: `new()` → `build()` → `fromDataAndExtension()` preserves salt and extension
  - Real OKX customer data that was failing in production

### Notes

- Fully backward compatible — `preInteraction` is optional, existing orders without it are unaffected

**Related Issue/Ticket:**
https://1inch.atlassian.net/browse/PT9-335

## Testing & Verification
**How was this tested?**
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing (describe steps)
- [ ] Verified on staging
<!-- Provide logs, screenshots, or steps to reproduce -->

## Risk Assessment
**Risk Level:**
- [x] **Low** - Minor changes, no operational impact
- [ ] **Medium** - Moderate changes, limited impact, standard rollback available
- [ ] **High** - Significant changes, potential operational impact, complex rollback

**Risks & Impact**
<!-- Describe any possible risks, such as migrations, downtime, or breaking changes, etc. -->
