### PR TITLE
doc(DPA2-2881): replace old 1inch business domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const connector = new PrivateKeyProviderConnector(
 )
 
 const sdk = new FusionSDK({
-    url: 'https://api.1inch.dev/fusion',
+    url: 'https://api.1inch.com/fusion',
     network: NetworkEnum.BINANCE,
     blockchainProvider: connector,
     authKey: DEV_PORTAL_API_TOKEN
@@ -133,7 +133,7 @@ const connector = new PrivateKeyProviderConnector(
 )
 
 const sdk = new FusionSDK({
-    url: 'https://api.1inch.dev/fusion',
+    url: 'https://api.1inch.com/fusion',
     network: NetworkEnum.BINANCE,
     blockchainProvider: connector,
     authKey: DEV_PORTAL_API_TOKEN

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,5 @@
 export class AuthError extends Error {
     constructor() {
-        super('Auth error, please use token from https://portal.1inch.dev/')
+        super('Auth error, please use token from https://business.1inch.com/portal')
     }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,7 @@
 export class AuthError extends Error {
     constructor() {
-        super('Auth error, please use token from https://business.1inch.com/portal')
+        super(
+            'Auth error, please use token from https://business.1inch.com/portal'
+        )
     }
 }

--- a/src/sdk/README.md
+++ b/src/sdk/README.md
@@ -9,7 +9,7 @@ import {FusionSDK, NetworkEnum} from '@1inch/fusion-sdk'
 
 async function main() {
     const sdk = new FusionSDK({
-        url: 'https://api.1inch.dev/fusion',
+        url: 'https://api.1inch.com/fusion',
         network: NetworkEnum.ETHEREUM,
         authKey: 'your-auth-key'
     })
@@ -78,7 +78,7 @@ class CustomHttpProvider implements HttpProviderConnector {
 ```typescript
 import {FusionSDK, NetworkEnum} from '@1inch/fusion-sdk'
 const sdk = new FusionSDK({
-    url: 'https://api.1inch.dev/fusion',
+    url: 'https://api.1inch.com/fusion',
     network: NetworkEnum.ETHEREUM
 })
 const orders = await sdk.getActiveOrders({page: 1, limit: 2})
@@ -97,7 +97,7 @@ const orders = await sdk.getActiveOrders({page: 1, limit: 2})
 ```typescript
 import {FusionSDK, NetworkEnum} from '@1inch/fusion-sdk'
 const sdk = new FusionSDK({
-    url: 'https://api.1inch.dev/fusion',
+    url: 'https://api.1inch.com/fusion',
     network: NetworkEnum.ETHEREUM
 })
 
@@ -121,7 +121,7 @@ const orders = await sdk.getOrdersByMaker({
 ```typescript
 import {FusionSDK, NetworkEnum, QuoteParams} from '@1inch/fusion-sdk'
 const sdk = new FusionSDK({
-    url: 'https://api.1inch.dev/fusion',
+    url: 'https://api.1inch.com/fusion',
     network: NetworkEnum.ETHEREUM
 })
 
@@ -146,7 +146,7 @@ const quote = await sdk.getQuote(params)
 ```typescript
 import {FusionSDK, NetworkEnum, QuoteParams} from '@1inch/fusion-sdk'
 const sdk = new FusionSDK({
-    url: 'https://api.1inch.dev/fusion',
+    url: 'https://api.1inch.com/fusion',
     network: NetworkEnum.ETHEREUM
 })
 
@@ -194,7 +194,7 @@ const blockchainProvider = new PrivateKeyProviderConnector(
 )
 
 const sdk = new FusionSDK({
-    url: 'https://api.1inch.dev/fusion',
+    url: 'https://api.1inch.com/fusion',
     network: 1,
     blockchainProvider
 })

--- a/src/ws-api/README.md
+++ b/src/ws-api/README.md
@@ -8,7 +8,7 @@
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const wsSdk = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM,
     authKey: 'your-auth-key'
 })
@@ -26,7 +26,7 @@ wsSdk.order.onOrder((data) => {
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM,
     authKey: 'your-auth-key'
 })
@@ -43,7 +43,7 @@ class MyFancyProvider implements WsProviderConnector {
     // ... user implementation
 }
 
-const url = 'wss://api.1inch.dev/fusion/ws/v2.0/1'
+const url = 'wss://api.1inch.com/fusion/ws/v2.0/1'
 const provider = new MyFancyProvider({url})
 
 const wsSdk = new WebSocketApi(provider)
@@ -55,7 +55,7 @@ const wsSdk = new WebSocketApi(provider)
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = WebSocketApi.new({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM
 })
 ```
@@ -68,7 +68,7 @@ By default, when user creates an instance of WebSocketApi, it automatically open
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM,
     lazyInit: true
 })
@@ -95,7 +95,7 @@ ws.init()
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM
 })
 
@@ -125,7 +125,7 @@ ws.on('message', function message(data) {
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM
 })
 
@@ -158,7 +158,7 @@ ws.off('message', message)
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM
 })
 
@@ -181,7 +181,7 @@ ws.onOpen(() => {
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM
 })
 
@@ -198,7 +198,7 @@ ws.send('my message')
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM
 })
 
@@ -219,7 +219,7 @@ ws.close()
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM
 })
 
@@ -238,7 +238,7 @@ ws.onMessage((data) => {
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM
 })
 
@@ -261,7 +261,7 @@ ws.onClose(() => {
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM
 })
 
@@ -286,7 +286,7 @@ ws.onError((error) => {
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM
 })
 
@@ -314,7 +314,7 @@ ws.order.onOrder((data) => {
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM
 })
 
@@ -337,7 +337,7 @@ ws.order.onOrderCreated((data) => {
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM
 })
 
@@ -360,7 +360,7 @@ ws.order.onOrderInvalid((data) => {
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM
 })
 
@@ -383,7 +383,7 @@ ws.order.onOrderBalanceOrAllowanceChange((data) => {
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM
 })
 
@@ -406,7 +406,7 @@ ws.order.onOrderFilled((data) => {
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM
 })
 
@@ -429,7 +429,7 @@ ws.order.onOrderFilledPartially((data) => {
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM
 })
 
@@ -454,7 +454,7 @@ ws.order.onOrderCancelled((data) => {
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM
 })
 
@@ -473,7 +473,7 @@ ws.rpc.onPong((data) => {
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM
 })
 
@@ -490,7 +490,7 @@ ws.rpc.ping()
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM
 })
 
@@ -511,7 +511,7 @@ ws.rpc.getAllowedMethods()
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM
 })
 
@@ -530,7 +530,7 @@ ws.rpc.onGetAllowedMethods((data) => {
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM
 })
 
@@ -551,7 +551,7 @@ ws.rpc.getActiveOrders()
 import {WebSocketApi, NetworkEnum} from '@1inch/fusion-sdk'
 
 const ws = new WebSocketApi({
-    url: 'wss://api.1inch.dev/fusion/ws',
+    url: 'wss://api.1inch.com/fusion/ws',
     network: NetworkEnum.ETHEREUM
 })
 


### PR DESCRIPTION
## Change Summary
**What does this PR change?**
Replace old 1inch business urls with new one

## Testing & Verification
**How was this tested?**
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing (describe steps)
- [ ] Verified on staging
<!-- Provide logs, screenshots, or steps to reproduce -->

## Risk Assessment
**Risk Level:**
- [ ] **Low** - Minor changes, no operational impact
- [ ] **Medium** - Moderate changes, limited impact, standard rollback available
- [ ] **High** - Significant changes, potential operational impact, complex rollback

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation examples and an `AuthError` message string; no runtime behavior beyond user-facing text is altered.
> 
> **Overview**
> Updates all Fusion SDK and WebSocket documentation examples to use the production `api.1inch.com` HTTP/WSS endpoints instead of `api.1inch.dev`.
> 
> Adjusts the `AuthError` message to direct users to the new token portal at `https://business.1inch.com/portal`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e11bf5cb932ba7c697e671910e28d5c1b37efb12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->