### PR TITLE
feat: add Robinhood chain (4663) support to v2 line

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "@1inch/byte-utils": "^3.1.0",
-        "@1inch/limit-order-sdk": "5.2.2",
+        "@1inch/limit-order-sdk": "5.3.1",
         "ethers": "^6.13.1",
         "tslib": "^2.6.3",
         "ws": "^8.17.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0(assert@2.1.0)
       '@1inch/limit-order-sdk':
-        specifier: 5.2.2
-        version: 5.2.2(assert@2.1.0)(axios@1.12.2)
+        specifier: 5.3.1
+        version: 5.3.1(assert@2.1.0)(axios@1.12.2)
       assert:
         specifier: ^2.0.0
         version: 2.1.0
@@ -35,7 +35,7 @@ importers:
     devDependencies:
       '@1inch/eslint-config':
         specifier: 3.0.6
-        version: 3.0.6(hbs5m4fewotxmhqz6muobnunxa)
+        version: 3.0.6(6c037112769e9469a8ba5c98a8ace5b6)
       '@1inch/tsconfig':
         specifier: 1.0.8
         version: 1.0.8
@@ -74,7 +74,7 @@ importers:
         version: 9.1.2(eslint@9.27.0)
       eslint-config-standard:
         specifier: ^17.1.0
-        version: 17.1.0(eslint-plugin-import@2.30.0(@typescript-eslint/parser@5.51.0(eslint@9.27.0)(typescript@4.9.4))(eslint-import-resolver-typescript@3.6.3)(eslint@9.27.0))(eslint-plugin-n@17.23.1(eslint@9.27.0)(typescript@4.9.4))(eslint-plugin-promise@6.6.0(eslint@9.27.0))(eslint@9.27.0)
+        version: 17.1.0(eslint-plugin-import@2.30.0)(eslint-plugin-n@17.23.1(eslint@9.27.0)(typescript@4.9.4))(eslint-plugin-promise@6.6.0(eslint@9.27.0))(eslint@9.27.0)
       eslint-import-resolver-typescript:
         specifier: 3.6.3
         version: 3.6.3(@typescript-eslint/parser@5.51.0(eslint@9.27.0)(typescript@4.9.4))(eslint-plugin-import@2.30.0)(eslint@9.27.0)
@@ -157,8 +157,8 @@ packages:
       prettier: ^3.3.2
       typescript: ^5.5.2
 
-  '@1inch/limit-order-sdk@5.2.2':
-    resolution: {integrity: sha512-zUvo4kpc1hCUx2znUUhYrRl2vdAsao6ubJIUngtM5Kpz07zHKLIIS/FarY2AktZeHQiUTotTrj7C1h9HjCQYow==}
+  '@1inch/limit-order-sdk@5.3.1':
+    resolution: {integrity: sha512-STEKaWd+/0xcy13RYsASUdkGI79IflMIZWzakaesy1wHjaPMnkXuqHm0wS0WOUYIlqZK0CwtcCLXK+NO7ZBQGw==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       assert: ^2.0.0
@@ -583,24 +583,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.5.25':
     resolution: {integrity: sha512-UckUfDYedish/bj2V1jgQDGgouLhyRpG7jgF3mp8jHir11V2K6JiTyjFoz99eOiclS3+hNdr4QLJ+ifrQMJNZw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.5.25':
     resolution: {integrity: sha512-LwbJEgNT3lXbvz4WFzVNXNvs8DvxpoXjMZk9K9Hig8tmZQJKHC2qZTGomcyK5EFzfj2HBuBXZnAEW8ZT9PcEaA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.5.25':
     resolution: {integrity: sha512-rsepMTgml0EkswWkBpg3Wrjj5eqjwTzZN5omAn1klzXSZnClTrfeHvBuoIJYVr1yx+jmBkqySgME2p7+magUAw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.5.25':
     resolution: {integrity: sha512-DJDsLBsRBV3uQBShRK2x6fqzABp9RLNVxDUpTTvUjc7qywJ8vS/yn+POK/zCyVEqLagf1z/8D5CEQ+RAIJq1NA==}
@@ -1448,12 +1452,12 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  ethers@6.13.5:
-    resolution: {integrity: sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ==}
-    engines: {node: '>=14.0.0'}
-
   ethers@6.15.0:
     resolution: {integrity: sha512-Kf/3ZW54L4UT0pZtsY/rf+EkBU7Qi5nnhonjUb8yTXcxH3cdcWrV2cRyk0Xk/4jK6OoHhxxZHriyhje20If2hQ==}
+    engines: {node: '>=14.0.0'}
+
+  ethers@6.16.0:
+    resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
     engines: {node: '>=14.0.0'}
 
   events@3.3.0:
@@ -2769,7 +2773,7 @@ snapshots:
     optionalDependencies:
       assert: 2.1.0
 
-  '@1inch/eslint-config@3.0.6(hbs5m4fewotxmhqz6muobnunxa)':
+  '@1inch/eslint-config@3.0.6(6c037112769e9469a8ba5c98a8ace5b6)':
     dependencies:
       '@eslint/compat': 1.4.0(eslint@9.27.0)
       '@eslint/eslintrc': 3.3.1
@@ -2779,7 +2783,7 @@ snapshots:
       '@typescript-eslint/parser': 5.51.0(eslint@9.27.0)(typescript@4.9.4)
       eslint: 9.27.0
       eslint-config-prettier: 9.1.2(eslint@9.27.0)
-      eslint-config-standard: 17.1.0(eslint-plugin-import@2.30.0(@typescript-eslint/parser@5.51.0(eslint@9.27.0)(typescript@4.9.4))(eslint-import-resolver-typescript@3.6.3)(eslint@9.27.0))(eslint-plugin-n@17.23.1(eslint@9.27.0)(typescript@4.9.4))(eslint-plugin-promise@6.6.0(eslint@9.27.0))(eslint@9.27.0)
+      eslint-config-standard: 17.1.0(eslint-plugin-import@2.30.0)(eslint-plugin-n@17.23.1(eslint@9.27.0)(typescript@4.9.4))(eslint-plugin-promise@6.6.0(eslint@9.27.0))(eslint@9.27.0)
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@5.51.0(eslint@9.27.0)(typescript@4.9.4))(eslint-plugin-import@2.30.0)(eslint@9.27.0)
       eslint-plugin-import: 2.30.0(@typescript-eslint/parser@5.51.0(eslint@9.27.0)(typescript@4.9.4))(eslint-import-resolver-typescript@3.6.3)(eslint@9.27.0)
       eslint-plugin-n: 17.23.1(eslint@9.27.0)(typescript@4.9.4)
@@ -2791,10 +2795,10 @@ snapshots:
       semver: 7.7.2
       typescript: 4.9.4
 
-  '@1inch/limit-order-sdk@5.2.2(assert@2.1.0)(axios@1.12.2)':
+  '@1inch/limit-order-sdk@5.3.1(assert@2.1.0)(axios@1.12.2)':
     dependencies:
       '@1inch/byte-utils': 3.0.0(assert@2.1.0)
-      ethers: 6.13.5
+      ethers: 6.16.0
     optionalDependencies:
       assert: 2.1.0
       axios: 1.12.2
@@ -4202,7 +4206,7 @@ snapshots:
     dependencies:
       eslint: 9.27.0
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.30.0(@typescript-eslint/parser@5.51.0(eslint@9.27.0)(typescript@4.9.4))(eslint-import-resolver-typescript@3.6.3)(eslint@9.27.0))(eslint-plugin-n@17.23.1(eslint@9.27.0)(typescript@4.9.4))(eslint-plugin-promise@6.6.0(eslint@9.27.0))(eslint@9.27.0):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.30.0)(eslint-plugin-n@17.23.1(eslint@9.27.0)(typescript@4.9.4))(eslint-plugin-promise@6.6.0(eslint@9.27.0))(eslint@9.27.0):
     dependencies:
       eslint: 9.27.0
       eslint-plugin-import: 2.30.0(@typescript-eslint/parser@5.51.0(eslint@9.27.0)(typescript@4.9.4))(eslint-import-resolver-typescript@3.6.3)(eslint@9.27.0)
@@ -4223,7 +4227,7 @@ snapshots:
       debug: 4.4.3
       enhanced-resolve: 5.18.3
       eslint: 9.27.0
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.51.0(eslint@9.27.0)(typescript@4.9.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.51.0(eslint@9.27.0)(typescript@4.9.4))(eslint-plugin-import@2.30.0)(eslint@9.27.0))(eslint@9.27.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.51.0(eslint@9.27.0)(typescript@4.9.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.27.0)
       fast-glob: 3.3.3
       get-tsconfig: 4.10.1
       is-bun-module: 1.3.0
@@ -4236,7 +4240,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.51.0(eslint@9.27.0)(typescript@4.9.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.51.0(eslint@9.27.0)(typescript@4.9.4))(eslint-plugin-import@2.30.0)(eslint@9.27.0))(eslint@9.27.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.51.0(eslint@9.27.0)(typescript@4.9.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.27.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -4265,7 +4269,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.27.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.51.0(eslint@9.27.0)(typescript@4.9.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.51.0(eslint@9.27.0)(typescript@4.9.4))(eslint-plugin-import@2.30.0)(eslint@9.27.0))(eslint@9.27.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.51.0(eslint@9.27.0)(typescript@4.9.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.27.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -4393,7 +4397,7 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  ethers@6.13.5:
+  ethers@6.15.0:
     dependencies:
       '@adraffy/ens-normalize': 1.10.1
       '@noble/curves': 1.2.0
@@ -4406,7 +4410,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  ethers@6.15.0:
+  ethers@6.16.0:
     dependencies:
       '@adraffy/ens-normalize': 1.10.1
       '@noble/curves': 1.2.0

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,7 +13,8 @@ export enum NetworkEnum {
     COINBASE = 8453,
     LINEA = 59144,
     SONIC = 146,
-    UNICHAIN = 130
+    UNICHAIN = 130,
+    ROBINHOOD = 4663
 }
 
 export const ONE_INCH_LIMIT_ORDER_V4 =

--- a/src/fusion-order/constants.ts
+++ b/src/fusion-order/constants.ts
@@ -40,5 +40,8 @@ export const CHAIN_TO_WRAPPER = {
     ),
     [NetworkEnum.UNICHAIN]: new Address(
         '0x4200000000000000000000000000000000000006'
+    ),
+    [NetworkEnum.ROBINHOOD]: new Address(
+        '0x0bd7d308f8e1639fab988df18a8011f41eacad73'
     )
 }


### PR DESCRIPTION
## Summary

Backport Robinhood Chain (4663) support to the v2 maintenance line (2.1.x), mirroring what `main` already has:

- Add `ROBINHOOD = 4663` to `NetworkEnum` (`src/constants.ts`)
- Add Robinhood WETH `0x0bd7d308f8e1639fab988df18a8011f41eacad73` to `CHAIN_TO_WRAPPER` (`src/fusion-order/constants.ts`) — verified on-chain via `rpc.mainnet.chain.robinhood.com` (`name()`/`symbol()` = WETH, 18 decimals)
- Bump `@1inch/limit-order-sdk` from `5.2.2` to `5.3.1`, so `getLimitOrderContract(4663)` / `getLimitOrderV4Domain(4663)` resolve the Robinhood-specific `AggregationRouterV6` at `0x5a705de8982235a7fa45bb83dcacf03a211389c7` instead of falling through to the canonical router address. Robinhood Chain uses its own CREATE3 deployer, so 1inch contract addresses differ there; the escrow factory on Robinhood embeds this router address as its immutable limit-order-protocol reference, and the router's on-chain `eip712Domain()` returns `("1inch Aggregation Router", "6", 4663, 0x5a705de8982235a7fa45bB83dCaCf03a211389C7)`.

## Context

`@1inch/cross-chain-sdk` v1 (which pins fusion-sdk 2.1.12-rc.1) currently works around both gaps with a pnpm override forcing limit-order-sdk 5.3.1 plus a local wrapper map (see 1inch/cross-chain-sdk#90). Once this ships in a 2.1.x release, that workaround can be dropped in favor of a plain fusion-sdk version bump.

## Testing

- `pnpm lint:types`, `pnpm build`, `pnpm lint:ci` — clean (only pre-existing warnings)
- `pnpm test` — 16 suites, 77 tests pass
- Runtime check of built package: `CHAIN_TO_WRAPPER[4663]` = Robinhood WETH; `getLimitOrderContract(4663)` = `0x5a705de8982235a7fa45bb83dcacf03a211389c7`
